### PR TITLE
Fix error in has() function

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -118,7 +118,7 @@ exports.has = function(key) {
   const keysResult = this.keys();
   let hasKey;
 
-  if(keysResult) {
+  if (keysResult && keysResult.data) {
     hasKey = keysResult.data.filter(function(k) {
       return (k === key);
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-json-storage-sync",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Read and write data to JSON-files in userData directory synchronously.",
   "main": "lib/storage.js",
   "scripts": {


### PR DESCRIPTION
An Exception occurs when calling the `has` function and the storagedir
wasn't created yet. In that case `keys()` called by `has` returns an error
object, which doesn't contain the required `data` array.